### PR TITLE
Qiita2本目　MAP推定を用いた回帰

### DIFF
--- a/trainee/tsuno/final_report/正規分布.ipynb
+++ b/trainee/tsuno/final_report/正規分布.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 後で正規分布について少しプロットする"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## 取り組んだトレーニングの概要
授業やワークアウトで学んだ知識内容を整理し，Qiitaに投稿する記事としてまとめる．ここでは，機械学習で頻出するMAP推定について，自分が理解できているか確認します．具体的には，MAP推定を用いて回帰モデルに関するパラメータなどの数式を導出した後，スクラッチによる実装を行います．

close #104 　

Hackmdの記事を分割するときにコメントまではコピーできないようなので，2つURLを載せていますが，上のURLの方にこれからはコメントをしていただきたいです．下のURLは，これまでのコメントを確認するために残しています．紛らわしくてすみません．

QiitaのURL: https://qiita.com/tsnry7913/items/b9f15953191e5e08d5af

HackmdのURL: https://hackmd.io/sSZFdse9R565yNzMPBHPcQ


## 獲得を目指したスキル
- MAP推定の数式の導出
- スクラッチによる実装

## Action list
- 機械学習基礎1Bの授業資料を読んだ
- PRML（上）を読んだ
- スクラッチ実装

## レビュワーへの質問

## 感想
MAP推定の地固めができて良かった．実装に関しても，動作して良かった．
